### PR TITLE
Fix: exporting correct type for useScriptLoader

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,7 +29,12 @@ module.exports = {
     },
   },
   extends: baseExtends,
-  ignorePatterns: ["dist/**/*", "jest.config*"],
+  ignorePatterns: [
+    "dist/**/*",
+    "jest.config*",
+    "useScriptLoader/index.d.ts",
+    "scriptloader-support/index.d.ts",
+  ],
   env: { es6: true },
   parserOptions: { ecmaVersion: 2021, sourceType: "module" },
   overrides: [

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
   ],
   "scripts": {
     "test": "eslint --quiet . && tsc --noEmit --project ./tsconfig.json && jest",
-    "build": "tsc --project ./tsconfig.json",
+    "build": "npm run build:base && npm run build:useScriptLoader && npm run build:scriptloader-support",
+    "build:base": "tsc --project ./tsconfig.json",
+    "build:useScriptLoader": "tsc --project ./useScriptLoader/tsconfig.json",
+    "build:scriptloader-support": "tsc --project ./scriptloader-support/tsconfig.json",
     "prepack": "npm run build"
   },
   "repository": {

--- a/scriptloader-support/index.d.ts
+++ b/scriptloader-support/index.d.ts
@@ -1,1 +1,2 @@
-export * from "../src/scriptloader-support";
+export = supportExports;
+import supportExports = require("../dist/scriptloader-support");

--- a/scriptloader-support/tsconfig.json
+++ b/scriptloader-support/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.json",
+  "include": ["./index.js"],
+  "exclude": [],
+  "compilerOptions": {
+    "emitDeclarationOnly": true,
+    "rootDir": "./",
+    "outDir": "./"
+  }
+}

--- a/src/hooks/useScriptLoader.ts
+++ b/src/hooks/useScriptLoader.ts
@@ -11,7 +11,7 @@ export interface ScriptLoader {
   (config: ScriptLoaderConfiguration): void;
 }
 
-const useScriptLoader: ScriptLoader = (config) => {
+export default (function useScriptLoader(config) {
   const {
     source,
     onSuccess,
@@ -40,6 +40,4 @@ const useScriptLoader: ScriptLoader = (config) => {
     };
     void waitForSource();
   }, [source, successFunc, errorFunc]);
-};
-
-export default useScriptLoader;
+} as ScriptLoader);

--- a/useScriptLoader/index.d.ts
+++ b/useScriptLoader/index.d.ts
@@ -1,1 +1,2 @@
-export * from "../src/hooks/useScriptLoader";
+export = useScriptLoaderExports;
+import useScriptLoaderExports = require("../dist/hooks/useScriptLoader");

--- a/useScriptLoader/tsconfig.json
+++ b/useScriptLoader/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.json",
+  "include": ["./index.js"],
+  "exclude": [],
+  "compilerOptions": {
+    "emitDeclarationOnly": true,
+    "rootDir": "./",
+    "outDir": "./"
+  }
+}


### PR DESCRIPTION
We're now generating the declaration files using typescript instead of manually for additional package folders.